### PR TITLE
Refactor: Split service dependencies and Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,29 +2,14 @@ FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-# Copy application code
-COPY . .
+# Copy requirements file
+COPY requirements-api.txt .
 
 # Install build dependencies, then Python packages, then remove build dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        build-essential \
-        python3-dev \
-        libxml2-dev \
-        libxslt-dev \
-        curl \
-        wget \
-        gnupg && \
-    pip install --no-cache-dir -e . && \
-    apt-get purge -y --auto-remove \
-        build-essential \
-        python3-dev \
-        libxml2-dev \
-        libxslt-dev \
-        curl \
-        wget \
-        gnupg && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update &&     apt-get install -y --no-install-recommends         build-essential         python3-dev         libxml2-dev         libxslt-dev         curl         wget         gnupg &&     pip install --no-cache-dir -r requirements-api.txt &&     apt-get purge -y --auto-remove         build-essential         python3-dev         libxml2-dev         libxslt-dev         curl         wget         gnupg &&     rm -rf /var/lib/apt/lists/*
+
+# Copy application code
+COPY . .
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile.api.old
+++ b/Dockerfile.api.old
@@ -1,0 +1,36 @@
+FROM python:3.11-slim-bookworm
+
+WORKDIR /app
+
+# Copy application code
+COPY . .
+
+# Install build dependencies, then Python packages, then remove build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        libxml2-dev \
+        libxslt-dev \
+        curl \
+        wget \
+        gnupg && \
+    pip install --no-cache-dir -e . && \
+    apt-get purge -y --auto-remove \
+        build-essential \
+        python3-dev \
+        libxml2-dev \
+        libxslt-dev \
+        curl \
+        wget \
+        gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Default command runs the API server
+CMD ["python3", "-m", "viralStoryGenerator.src.worker_runner", "api", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.queue.old
+++ b/Dockerfile.queue.old
@@ -1,0 +1,33 @@
+FROM python:3.11-slim-bookworm
+
+WORKDIR /app
+
+# Copy application code
+COPY . .
+
+# Install build dependencies, then Python packages, then remove build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        libxml2-dev \
+        libxslt-dev \
+        curl \
+        wget \
+        gnupg && \
+    pip install --no-cache-dir -e . && \
+    apt-get purge -y --auto-remove \
+        build-essential \
+        python3-dev \
+        libxml2-dev \
+        libxslt-dev \
+        curl \
+        wget \
+        gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+
+# Command to run the worker
+CMD ["python3", "-m", "viralStoryGenerator.src.worker_runner", "worker", "--worker-type", "queue"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,8 +2,8 @@ FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-# Copy application code
-COPY . .
+# Copy requirements file first for better caching
+COPY requirements-scraper.txt .
 
 # Install system dependencies for playwright and build tools
 RUN apt-get update && \
@@ -37,7 +37,7 @@ RUN apt-get update && \
         libpango-1.0-0 \
         libcairo2 \
         libgdk-pixbuf2.0-0 && \
-    pip install --no-cache-dir -e . && \
+    pip install --no-cache-dir -r requirements-scraper.txt && \
     playwright install --with-deps && \
     apt-get purge -y --auto-remove \
         build-essential \
@@ -48,6 +48,9 @@ RUN apt-get update && \
         wget \
         gnupg && \
     rm -rf /var/lib/apt/lists/*
+
+# Copy application code after dependencies are installed
+COPY . .
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile.workerapi
+++ b/Dockerfile.workerapi
@@ -2,29 +2,14 @@ FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-# Copy application code
-COPY . .
+# Copy requirements file
+COPY requirements-queue.txt .
 
 # Install build dependencies, then Python packages, then remove build dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        build-essential \
-        python3-dev \
-        libxml2-dev \
-        libxslt-dev \
-        curl \
-        wget \
-        gnupg && \
-    pip install --no-cache-dir -e . && \
-    apt-get purge -y --auto-remove \
-        build-essential \
-        python3-dev \
-        libxml2-dev \
-        libxslt-dev \
-        curl \
-        wget \
-        gnupg && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update &&     apt-get install -y --no-install-recommends         build-essential         python3-dev         libxml2-dev         libxslt-dev         curl         wget         gnupg &&     pip install --no-cache-dir -r requirements-queue.txt &&     apt-get purge -y --auto-remove         build-essential         python3-dev         libxml2-dev         libxslt-dev         curl         wget         gnupg &&     rm -rf /var/lib/apt/lists/*
+
+# Copy application code
+COPY . .
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,15 @@
+fastapi==0.115.9
+uvicorn==0.34.0
+python-dotenv==1.0.0
+redis==5.2.1
+prometheus-client==0.16.0
+pydantic==2.11.2
+python-multipart==0.0.6
+boto3==1.37.28
+azure-storage-blob==12.16.0
+pydantic-settings==2.0.0
+typing-extensions>=4.13.2
+aiohttp>=3.11.18
+asyncio==3.4.3
+torch==2.3.1
+httpx>=0.28.1

--- a/requirements-queue.txt
+++ b/requirements-queue.txt
@@ -1,0 +1,17 @@
+redis==5.2.1
+python-dotenv==1.0.0
+requests==2.32.3
+boto3==1.37.28
+azure-storage-blob==12.16.0
+crawl4ai==0.6.3
+beautifulsoup4==4.12.0
+lxml~=5.3.0
+sentence-transformers==2.2.2
+chromadb>=1.0.9
+torch==2.3.1
+pydantic==2.11.2
+pydantic-settings==2.0.0
+typing-extensions>=4.13.2
+tenacity==8.2.3
+asyncio==3.4.3
+httpx>=0.28.1

--- a/requirements-scraper.txt
+++ b/requirements-scraper.txt
@@ -1,0 +1,13 @@
+crawl4ai==0.6.3
+redis==5.2.1
+python-dotenv==1.0.0
+beautifulsoup4==4.12.0
+lxml~=5.3.0
+typing-extensions>=4.13.2
+asyncio==3.4.3
+pydantic==2.11.2
+torch==2.3.1
+pydantic-settings==2.0.0
+boto3==1.37.28
+azure-storage-blob==12.16.0
+httpx>=0.28.1


### PR DESCRIPTION


This change isolates dependencies for the API, Scraper, and Queue services to reduce Docker image sizes and improve build/load times.

Key changes:
- I created service-specific requirements files:
    - `requirements-api.txt`
    - `requirements-scraper.txt`
    - `requirements-queue.txt`
- I updated `Dockerfile`, `Dockerfile.worker`, and `Dockerfile.workerapi` to use their respective new requirements files.
- I optimized Dockerfile caching by ensuring `COPY . .` comes after Python package installation.
- I renamed the original `Dockerfile` and `Dockerfile.workerapi` to `.old` versions during the update process because I had some limitations in editing them directly; I then created new files with the correct content. You can remove the old files after verification.
- The main `requirements.txt` is no longer directly used for Docker builds of these services but may remain for your local development convenience.
- `docker-compose.yml` and `docker-compose.prod.yml` did not require changes as they already referred to the correct Dockerfile names.

This refactoring aims to create more efficient and maintainable Docker builds for each service.